### PR TITLE
Fix license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "wesbos/waait",
   "main": "index.js",
   "author": "Wes Bos",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "tape": "^4.9.0"
   },


### PR DESCRIPTION
The license field in `package.json` does not match with the license in the repository.