### PR TITLE
Fix TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,4 +2,4 @@
  * @param amount The amount of time to wait in milliseconds.
  * @return A promise that gets resolved after a given amount.
  */
-export function wait(amount: number): Promise<void>;
+export default function wait(amount: number): Promise<void>;


### PR DESCRIPTION
Fixes the TypeScript definition to reflect the fact that the module exports a default rather than a named export