### PR TITLE
Update typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,4 +2,4 @@
  * @param amount The amount of time to wait in milliseconds.
  * @return A promise that gets resolved after a given amount.
  */
-export default function wait(amount: number): Promise<void>;
+export default function wait(amount?: number): Promise<void>;


### PR DESCRIPTION
Super minor detail, but `wait` has a default argument of `0` and so its argument is optional.