### PR TITLE
Fix TS definition - amount is optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,4 +2,4 @@
  * @param amount The amount of time to wait in milliseconds.
  * @return A promise that gets resolved after a given amount.
  */
-export default function wait(amount: number): Promise<void>;
+export default function wait(amount?: number): Promise<void>;


### PR DESCRIPTION
Hi!

This one fixes TS definitions - `amount` is optional (`amount = 0`)

Thanks!