### PR TITLE
Fix type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,4 +2,6 @@
  * @param amount The amount of time to wait in milliseconds.
  * @return A promise that gets resolved after a given amount.
  */
-export default function wait(amount?: number): Promise<void>;
+declare function wait(amount?: number): Promise<void>;
+
+export = wait


### PR DESCRIPTION
`export default` is the correct type for either ESM packages that use `export default`, or a CJS module that assigns to `module.exports.default`.

The correct type definition for CJS using `module.exports =`, is `export =`.